### PR TITLE
Fixed error when there is a playlistid or channelid

### DIFF
--- a/app/src/main/java/com/techiesatish/youtubeintegration/ChannelActivity.java
+++ b/app/src/main/java/com/techiesatish/youtubeintegration/ChannelActivity.java
@@ -53,16 +53,18 @@ public class ChannelActivity extends AppCompatActivity {
                         JSONObject jsonsnippet= jsonObject1.getJSONObject("snippet");
                         JSONObject jsonObjectdefault = jsonsnippet.getJSONObject("thumbnails").getJSONObject("medium");
                         VideoDetails videoDetails=new VideoDetails();
+                        
+                        if(jsonVideoId.has("videoId")) {
+                            String videoid = jsonVideoId.getString("videoId");
 
-                        String videoid=jsonVideoId.getString("videoId");
+                            Log.e(TAG, " New Video Id " + videoid);
+                            videoDetails.setURL(jsonObjectdefault.getString("url"));
+                            videoDetails.setVideoName(jsonsnippet.getString("title"));
+                            videoDetails.setVideoDesc(jsonsnippet.getString("description"));
+                            videoDetails.setVideoId(videoid);
 
-                        Log.e(TAG," New Video Id" +videoid);
-                        videoDetails.setURL(jsonObjectdefault.getString("url"));
-                        videoDetails.setVideoName(jsonsnippet.getString("title"));
-                        videoDetails.setVideoDesc(jsonsnippet.getString("description"));
-                           videoDetails.setVideoId(videoid);
-
-                        videoDetailsArrayList.add(videoDetails);
+                            videoDetailsArrayList.add(videoDetails);
+                        }
                     }
                     lvVideo.setAdapter(customListAdapter);
                     customListAdapter.notifyDataSetChanged();


### PR DESCRIPTION
When receiving data from API, we could receive something like 

"id": {
    "kind": "youtube#playlist",
    "playlistId": "PLI-lPmVKmzvlpjVw9LH_jtgGJUcDMQi0I"
   },

And the program was getting JSONException..

This fix remove this error and loads only videoids